### PR TITLE
Save the login information about OneDrive

### DIFF
--- a/src/main/java/org/elastos/hive/AuthToken.java
+++ b/src/main/java/org/elastos/hive/AuthToken.java
@@ -1,19 +1,14 @@
 package org.elastos.hive;
 
 public class AuthToken implements ResultItem {
-	@SuppressWarnings("unused")
-	private final String scope;
 	private final String refreshToken;
 	private final String accessToken;
 	private long experitime;
-	private final long createdTime;
 
-	public AuthToken(String scope, String refreshToken, String accessToken, long experitime) {
-		this.scope = scope;
-		this.accessToken = accessToken;
+	public AuthToken(String refreshToken, String accessToken, long experitime) {
 		this.refreshToken = refreshToken;
+		this.accessToken = accessToken;
 		this.experitime = experitime;
-		this.createdTime = System.currentTimeMillis() / 1000;
 	}
 
 	public String getRefreshToken() {
@@ -24,9 +19,13 @@ public class AuthToken implements ResultItem {
 		return accessToken;
 	}
 
+	public long getExpiredTime() {
+		return experitime;
+	}
+
 	public boolean isExpired() {
 		long currentSeconds = System.currentTimeMillis() / 1000;
-		if (currentSeconds >= (createdTime + experitime)) {
+		if (currentSeconds >= experitime) {
 			return true;
 		}
 

--- a/src/main/java/org/elastos/hive/vendors/onedrive/OneDriveParameter.java
+++ b/src/main/java/org/elastos/hive/vendors/onedrive/OneDriveParameter.java
@@ -6,9 +6,11 @@ import org.elastos.hive.Parameter;
 
 public class OneDriveParameter implements Parameter<OAuthEntry> {
 	private final OAuthEntry authEntry;
+	private final String keyStorePath;
 
-	public OneDriveParameter(OAuthEntry data) {
+	public OneDriveParameter(OAuthEntry data, String storePath) {
 		this.authEntry = data;
+		this.keyStorePath = storePath;
 	}
 
 	@Override
@@ -23,7 +25,6 @@ public class OneDriveParameter implements Parameter<OAuthEntry> {
 
 	@Override
 	public String getKeyStorePath() {
-		// TODO
-		return null;
+		return keyStorePath;
 	}
 }

--- a/src/main/java/org/elastos/hive/vendors/onedrive/OneDriveUtils.java
+++ b/src/main/java/org/elastos/hive/vendors/onedrive/OneDriveUtils.java
@@ -1,0 +1,12 @@
+package org.elastos.hive.vendors.onedrive;
+
+class OneDriveUtils {
+	static final String CONFIG  		= "onedrive.json";
+	static final String TMP 			= ".tmp";
+	static final String ClientId 		= "client_id";
+	static final String Scope 			= "Scope";
+	static final String RedirectUrl 	= "redirect_url";
+	static final String AccessToken 	= "access_token";
+	static final String RefreshToken	= "refresh_token";
+	static final String ExpiresAt 		= "expires_at";
+}

--- a/src/test/java/org/elastos/hive/OneDriveTestBase.java
+++ b/src/test/java/org/elastos/hive/OneDriveTestBase.java
@@ -29,7 +29,7 @@ public class OneDriveTestBase {
 
 		try {
 			OAuthEntry entry = new OAuthEntry(APPID, SCOPE, REDIRECTURL);
-			OneDriveParameter parameter = new OneDriveParameter(entry);
+			OneDriveParameter parameter = new OneDriveParameter(entry, System.getProperty("user.dir"));
 
 			Client client = Client.createInstance(parameter);
 			assertNotNull(client);


### PR DESCRIPTION
1. Save the login information about OneDrive; 
2. Clear the local data when logout; 
3. If the local information is valid, use it when the user login.