### PR TITLE
Fixed the bug about OneDrive interfaces: Directory.getInfo

### DIFF
--- a/src/main/java/org/elastos/hive/vendors/ipfs/IPFSDirectory.java
+++ b/src/main/java/org/elastos/hive/vendors/ipfs/IPFSDirectory.java
@@ -498,6 +498,8 @@ class IPFSDirectory extends Directory  {
 			future.completeExceptionally(value.getException());
 			return future;
 		}
+		
+		value.setCallback(callback);
 
 		try {
 			ConnectionManager.getIPFSApi()
@@ -565,13 +567,13 @@ class IPFSDirectory extends Directory  {
 		private final String pathName ;
 		private final CompletableFuture future;
 		private final PackValue value;
-		private final IPFSConstance.Type type ;
+		private final IPFSConstance.Type type;
 
-		IPFSDirForResultCallback(CompletableFuture future , PackValue value , String pathName , IPFSConstance.Type type){
-			this.future = future ;
-			this.value = value ;
-			this.pathName = pathName ;
-			this.type = type ;
+		IPFSDirForResultCallback(CompletableFuture future, PackValue value, String pathName, IPFSConstance.Type type){
+			this.future = future;
+			this.value = value;
+			this.pathName = pathName;
+			this.type = type;
 		}
 
 		@Override
@@ -644,6 +646,7 @@ class IPFSDirectory extends Directory  {
 						callback.onSuccess(children);
 					}
 
+					value.setValue(children);
 					future.complete(children);
 					
 					break;

--- a/src/main/java/org/elastos/hive/vendors/onedrive/OneDriveFile.java
+++ b/src/main/java/org/elastos/hive/vendors/onedrive/OneDriveFile.java
@@ -129,13 +129,13 @@ final class OneDriveFile extends File {
 				.thenCompose(padding -> moveTo(padding, pathName, callback));
 	}
 
-	private CompletableFuture<Void> moveTo(Void padding, String pathName, Callback<Void> callback) {
+	private CompletableFuture<Void> moveTo(Void padding, String parentPath, Callback<Void> callback) {
 		CompletableFuture<Void> future = new CompletableFuture<Void>();
 
 		if (callback == null)
 			callback = new NullCallback<Void>();
 
-		if (!pathName.startsWith("/")) {
+		if (!parentPath.startsWith("/")) {
 			HiveException e = new HiveException("Neet a absolute path.");
 			callback.onError(e);
 			future.completeExceptionally(e);
@@ -149,7 +149,7 @@ final class OneDriveFile extends File {
 			return future;
 		}
 
-		if (this.pathName.equals(pathName)) {
+		if (this.pathName.equals(parentPath)) {
 			HiveException e = new HiveException("Can't move to same path name");
 			callback.onError(e);
 			future.completeExceptionally(e);
@@ -158,12 +158,12 @@ final class OneDriveFile extends File {
 
 		try {
 
-			int LastPos = pathName.lastIndexOf("/");
-			String name = pathName.substring(LastPos + 1);
+			int LastPos = this.pathName.lastIndexOf("/");
+			String name = this.pathName.substring(LastPos + 1);
 
-			String newPathName = pathName + "/" +name ;
+			String newPathName = parentPath + "/" +name ;
 
-			MoveAndCopyReqest request = new MoveAndCopyReqest(pathName,name);
+			MoveAndCopyReqest request = new MoveAndCopyReqest(parentPath, name);
 			ConnectionManager.getOnedriveApi()
 					.moveTo(this.pathName, request)
 					.enqueue(new FileCallback(future , callback ,newPathName, Type.MOVE_TO));
@@ -187,13 +187,13 @@ final class OneDriveFile extends File {
 				.thenCompose(padding -> copyTo(padding, pathName, callback));
 	}
 
-	private CompletableFuture<Void> copyTo(Void padding, String pathName, Callback<Void> callback) {
+	private CompletableFuture<Void> copyTo(Void padding, String parentPath, Callback<Void> callback) {
 		CompletableFuture<Void> future = new CompletableFuture<Void>();
 
 		if (callback == null)
 			callback = new NullCallback<Void>();
 
-		if (!pathName.startsWith("/")) {
+		if (!parentPath.startsWith("/")) {
 			HiveException e = new HiveException("Neet a absolute path.");
 			callback.onError(e);
 			future.completeExceptionally(e);
@@ -207,7 +207,7 @@ final class OneDriveFile extends File {
 			return future;
 		}
 
-		if (this.pathName.equals(pathName)) {
+		if (this.pathName.equals(parentPath)) {
 			HiveException e = new HiveException("Can't copy to same path name");
 			callback.onError(e);
 			future.completeExceptionally(e);
@@ -215,10 +215,10 @@ final class OneDriveFile extends File {
 		}
 
 		try {
-			int LastPos = pathName.lastIndexOf("/");
-			String name = pathName.substring(LastPos + 1);
+			int LastPos = this.pathName.lastIndexOf("/");
+			String name = this.pathName.substring(LastPos + 1);
 
-			MoveAndCopyReqest request = new MoveAndCopyReqest(pathName,name);
+			MoveAndCopyReqest request = new MoveAndCopyReqest(parentPath, name);
 			ConnectionManager.getOnedriveApi()
 					.copyTo(this.pathName, request)
 					.enqueue(new FileCallback(future, callback ,pathName, Type.COPY_TO));

--- a/src/main/java/org/elastos/hive/vendors/onedrive/network/OneDriveApi.java
+++ b/src/main/java/org/elastos/hive/vendors/onedrive/network/OneDriveApi.java
@@ -63,6 +63,9 @@ public interface OneDriveApi {
 
     @GET(OneDriveConstance.DRIVE+"/root:/{path}")
     Call<FileOrDirPropResponse> getDirAndFileInfo(@Path("path")String path);
+    
+    @GET(OneDriveConstance.DRIVE+"/root")
+    Call<FileOrDirPropResponse> getRootDirInfo();
 
     @PATCH(OneDriveConstance.DRIVE+"/root:{path}")
     Call<NoBodyEntity> moveTo(@Path("path")String path , @Body MoveAndCopyReqest moveAndCopyReqest);

--- a/src/test/java/org/elastos/hive/OneDrive/OneDriveClientTest.java
+++ b/src/test/java/org/elastos/hive/OneDrive/OneDriveClientTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.fail;
 
 public class OneDriveClientTest {
 	private static Client client;
+	private boolean callbackInvoked = false;
+
 	@Test public void testGetInstance() {
 		assertNotNull(Client.getInstance(DriveType.oneDrive));
 	}
@@ -38,22 +40,34 @@ public class OneDriveClientTest {
 
 	@Test
 	public void testGetInfoAsync(){
+		callbackInvoked = false;
 		Callback<Client.Info> callback = new Callback<Client.Info>() {
 			@Override
 			public void onError(HiveException e) {
 				e.printStackTrace();
+				fail();
 			}
 
 			@Override
 			public void onSuccess(Client.Info body) {
+				callbackInvoked = true;
 				Client.Info info = body ;
 				assertNotNull(info);
 				assertNotNull(info.get(Client.Info.userId));
-				assertNotNull(info.get(Client.Info.name));
+				assertTrue(info.containsKey(Client.Info.name));
+				assertTrue(info.containsKey(Client.Info.email));
+				assertTrue(info.containsKey(Client.Info.phoneNo));
+				assertTrue(info.containsKey(Client.Info.region));
 			}
 		};
 
-		client.getInfo(callback);
+		try {
+			client.getInfo(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetInfoAsync failed");
+		}
 	}
 
 	@Test public void testGetDefaultDrive() {
@@ -68,19 +82,28 @@ public class OneDriveClientTest {
 
 	@Test
 	public void testGetDefaultDriveAsync(){
+		callbackInvoked = false;
 		Callback<Drive> callback = new Callback<Drive>() {
 			@Override
 			public void onError(HiveException e) {
 				e.printStackTrace();
+				fail();
 			}
 
 			@Override
-			public void onSuccess(Drive body) {
-				Drive drive = body ;
-				assertNotNull(body);
+			public void onSuccess(Drive drive) {
+				callbackInvoked = true;
+				assertNotNull(drive);
 			}
 		};
-		client.getDefaultDrive(callback);
+
+		try {
+			client.getDefaultDrive(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetDefaultDriveAsync failed");
+		}
 	}
 
 	@BeforeClass

--- a/src/test/java/org/elastos/hive/OneDrive/OneDriveDirectoryTest.java
+++ b/src/test/java/org/elastos/hive/OneDrive/OneDriveDirectoryTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 
 import org.elastos.hive.*;
+import org.elastos.hive.Void;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -14,7 +15,9 @@ public class OneDriveDirectoryTest {
 	private static Drive drive;
 	private static Client client;
 	private static Directory testDirectory;
+	private static Directory testDirectoryAsync;
 	private static Directory parentDirForMoveTo;
+	private boolean callbackInvoked = false;
 
 	@Test public void testRootDirectory() {
 		try {
@@ -26,6 +29,31 @@ public class OneDriveDirectoryTest {
 		}
 	}
 
+	@Test public void testRootDirectoryAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+			}
+		};
+		
+		try {
+			drive.getRootDir(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testRootDirectoryAsync failed");
+		}
+	}
+	
 	@Test public void testGetId() {
 		assertNotNull(testDirectory.getId());
 	}
@@ -58,6 +86,50 @@ public class OneDriveDirectoryTest {
 			fail("getInfo failed");
 		}
 	}
+	
+	@Test public void testRootDirectoryGetInfo() {
+		try {
+			Directory root = drive.getRootDir().get();
+			assertNotNull(root);
+
+			Directory.Info info = root.getInfo().get();
+			assertNotNull(info);
+			assertNotNull(info.get(Directory.Info.itemId));
+			assertNotNull(info.get(Directory.Info.name));
+			assertTrue(info.containsKey(Directory.Info.childCount));
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testRootDirectoryGetInfo failed");
+		}
+	}
+
+	@Test public void testGetInfoAsync() {
+		callbackInvoked = false;
+		Callback<Directory.Info> callback = new Callback<Directory.Info>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory.Info info) {
+				callbackInvoked = true;
+				assertNotNull(info);
+				assertNotNull(info.get(Directory.Info.itemId));
+				assertNotNull(info.get(Directory.Info.name));
+				assertTrue(info.containsKey(Directory.Info.childCount));
+			}
+		};
+		
+		try {
+			testDirectory.getInfo(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetInfoAsync failed");
+		}
+	}
 
 	@Test public void testCreateDirectory() {
 		try {
@@ -70,6 +142,32 @@ public class OneDriveDirectoryTest {
 		}
 	}
 
+	@Test public void testCreateDirectoryAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+			}
+		};
+
+		try {
+			String childName = "testCreateDirectoryAsync" + System.currentTimeMillis();
+			testDirectory.createDirectory(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCreateDirectoryAsync failed");
+		}
+	}
+	
 	@Test public void testCreateDirectoryWithInvalidArg() {
 		try {
 			String childName = "/testCreateDirectory" + System.currentTimeMillis();
@@ -94,6 +192,36 @@ public class OneDriveDirectoryTest {
 			fail("testGetDirectory failed");
 		}
 	}
+	
+	@Test public void testGetDirectoryAsync() {
+		try {
+			String childName = "testGetDirectoryAsync" + System.currentTimeMillis();
+			Directory child = testDirectory.createDirectory(childName).get();
+			assertNotNull(child);
+
+			callbackInvoked = false;
+			Callback<Directory> callback = new Callback<Directory>() {
+				@Override
+				public void onError(HiveException e) {
+					e.printStackTrace();
+					fail();
+				}
+
+				@Override
+				public void onSuccess(Directory childDir) {
+					callbackInvoked = true;
+					assertNotNull(childDir);
+					assertEquals(child.getPath(), childDir.getPath());
+				}
+			};
+
+			testDirectory.getDirectory(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetDirectoryAsync failed");
+		}
+	}
 
 	@Test public void testCreateFile() {
 		try {
@@ -106,6 +234,32 @@ public class OneDriveDirectoryTest {
 		}
 	}
 
+	@Test public void testCreateFileAsync() {
+		callbackInvoked = false;
+		Callback<File> callback = new Callback<File>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(File file) {
+				callbackInvoked = true;
+				assertNotNull(file);
+			}
+		};
+
+		try {
+			String childName = "testCreateFileAsync" + System.currentTimeMillis();
+			testDirectory.createFile(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCreateFileAsync failed");
+		}
+	}
+	
 	@Test public void testCreateFileWithInvalidArg() {
 		try {
 			String childName = "/testCreateFileWithInvalidArg" + System.currentTimeMillis();
@@ -115,7 +269,7 @@ public class OneDriveDirectoryTest {
 			e.printStackTrace();
 		}
 	}
-
+	
 	@Test public void testGetFile() {
 		try {
 			String childName = "testGetFile" + System.currentTimeMillis();
@@ -129,6 +283,36 @@ public class OneDriveDirectoryTest {
 			fail("testGetFile failed");
 		}
 	}
+	
+	@Test public void testGetFileAsync() {
+		try {
+			String childName = "testGetFileAsync" + System.currentTimeMillis();
+			File child = testDirectory.createFile(childName).get();
+			assertNotNull(child);
+			
+			callbackInvoked = false;
+			Callback<File> callback = new Callback<File>() {
+				@Override
+				public void onError(HiveException e) {
+					e.printStackTrace();
+					fail();
+				}
+
+				@Override
+				public void onSuccess(File file) {
+					callbackInvoked = true;
+					assertNotNull(file);
+					assertEquals(child.getPath(), file.getPath());
+				}
+			};
+
+			testDirectory.getFile(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetFileAsync failed");
+		}
+	}
 
 	@Test public void testGetChildren() {
 		try {
@@ -137,6 +321,31 @@ public class OneDriveDirectoryTest {
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testGetChildren failed");
+		}
+	}
+	
+	@Test public void testGetChildrenAsync() {
+		callbackInvoked = false;
+		Callback<Children> callback = new Callback<Children>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Children child) {
+				callbackInvoked = true;
+				assertNotNull(child);
+			}
+		};
+		
+		try {
+			testDirectory.getChildren(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetChildrenAsync failed");
 		}
 	}
 
@@ -205,12 +414,12 @@ public class OneDriveDirectoryTest {
 	@Test public void testMoveTo() {
 		try {
 			String originPath = testDirectory.getPath();
+			int childCount = parentDirForMoveTo.getChildren().get().getContent().size();
 			testDirectory.moveTo(parentDirForMoveTo.getPath()).get();
 
 			//1. Check the parent has a new child.
-			Children children = parentDirForMoveTo.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			int newChildCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 
 			//2. Check: the origin and the new path is different
 			assertFalse(originPath.equals(testDirectory.getPath()));
@@ -224,25 +433,113 @@ public class OneDriveDirectoryTest {
 			}
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("testMoveToInvalid failed");
+			fail("testMoveTo failed");
 		}
 	}
 
+	@Test public void testMoveToAsync() {
+		callbackInvoked = false;
+		Callback<Void> callback = new Callback<Void>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Void none) {
+				callbackInvoked = true;
+			}
+		};
+
+		try {
+			int childCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			String originPath = testDirectoryAsync.getPath();
+			testDirectoryAsync.moveTo(parentDirForMoveTo.getPath(), callback).get();
+			assertTrue(callbackInvoked);
+
+			int newChildCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
+
+			//1. Check the parent has a new child.
+			Children children = parentDirForMoveTo.getChildren().get();
+			assertNotNull(children);
+			assertEquals(1, children.getContent().size());
+
+			//2. Check: the origin and the new path is different
+			assertFalse(originPath.equals(testDirectoryAsync.getPath()));
+
+			//3. Check: the origin path is invalid.
+			try {
+				drive.getDirectory(originPath).get();
+				fail(String.format("The a directory has moved, the origin path is invalid: %s", originPath));
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testMoveToAsync failed");
+		}
+	}
+	
 	@Test public void testCopyTo() {
 		Directory parentDir = null;
 		try {
 			String parentPath = "/copyToParentDir" + System.currentTimeMillis();
 			parentDir = drive.createDirectory(parentPath).get();
 			assertNotNull(parentDir);
+			
+			int childCount = parentDir.getChildren().get().getContent().size();
 			testDirectory.copyTo(parentPath).get();
 
 			Thread.sleep(5000);
-			Children children = parentDir.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testCopyTo failed");
+		}
+		finally {
+			try {
+				parentDir.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				fail();
+			}
+		}
+	}
+	
+	@Test public void testCopyToAsync() {
+		callbackInvoked = false;
+		Callback<Void> callback = new Callback<Void>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Void none) {
+				callbackInvoked = true;
+			}
+		};
+
+		Directory parentDir = null;
+		try {
+			String parentPath = "/copyToAsyncParentDir" + System.currentTimeMillis();
+			parentDir = drive.createDirectory(parentPath).get();
+			assertNotNull(parentDir);
+			
+			int childCount = parentDir.getChildren().get().getContent().size();
+			testDirectory.copyTo(parentPath, callback).get();
+			assertTrue(callbackInvoked);
+
+			Thread.sleep(5000);
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCopyToAsync failed");
 		}
 		finally {
 			try {
@@ -261,13 +558,14 @@ public class OneDriveDirectoryTest {
 			parentDir = drive.createDirectory(parentPath).get();
 			assertNotNull(parentDir);
 			String originPath = testDirectory.getPath();
+			
+			int childCount = parentDir.getChildren().get().getContent().size();
 			testDirectory.copyTo(parentPath).get();
 
 			//1. Check the parent has a new child.
-			Thread.sleep(2000);
-			Children children = parentDir.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			Thread.sleep(5000);
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 
 			//2. Check: the origin and the new path is same
 			assertEquals(originPath, testDirectory.getPath());
@@ -303,6 +601,10 @@ public class OneDriveDirectoryTest {
 			testDirectory = drive.createDirectory("/testDirectory" + System.currentTimeMillis()).get();
 			assertNotNull(testDirectory);
 			assertNotNull(testDirectory.getPath());
+			
+			testDirectoryAsync = drive.createDirectory("/testDirectoryAsync" + System.currentTimeMillis()).get();
+			assertNotNull(testDirectoryAsync);
+			assertNotNull(testDirectoryAsync.getPath());
 			parentDirForMoveTo = drive.createDirectory("/parentDirForMoveTo" + System.currentTimeMillis()).get();
 			assertNotNull(parentDirForMoveTo);
 		} catch (Exception e) {
@@ -314,6 +616,7 @@ public class OneDriveDirectoryTest {
     static public void tearDown() throws Exception {
     	try {
     		testDirectory.deleteItem().get();
+    		testDirectoryAsync.deleteItem().get();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/test/java/org/elastos/hive/OneDrive/OneDriveDriveTest.java
+++ b/src/test/java/org/elastos/hive/OneDrive/OneDriveDriveTest.java
@@ -2,14 +2,17 @@ package org.elastos.hive.OneDrive;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.ExecutionException;
 
+import org.elastos.hive.Callback;
 import org.elastos.hive.Client;
 import org.elastos.hive.Directory;
 import org.elastos.hive.Drive;
 import org.elastos.hive.File;
+import org.elastos.hive.HiveException;
 import org.elastos.hive.ItemInfo;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -18,6 +21,7 @@ import org.junit.Test;
 public class OneDriveDriveTest {
 	private static Drive drive;
 	private static Client client;
+	private boolean callbackInvoked = false;
 
 	@Test public void testGetInfo() {
 		try {
@@ -26,7 +30,33 @@ public class OneDriveDriveTest {
 			assertNotNull(info.get(Drive.Info.driveId));
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("getInfo failed");
+			fail("testGetInfo failed");
+		}
+    }
+	
+	@Test public void testGetInfoAsync() {
+		callbackInvoked = false;
+		Callback<Drive.Info> callback = new Callback<Drive.Info>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Drive.Info info) {
+				callbackInvoked = true;
+				assertNotNull(info);
+				assertNotNull(info.get(Drive.Info.driveId));
+			}
+		};
+		
+		try {
+			drive.getInfo(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetInfoAsync failed");
 		}
     }
 
@@ -42,14 +72,39 @@ public class OneDriveDriveTest {
 			assertNotNull(root);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("getRootDir failed");
+			fail("testGetRootDir failed");
+		}
+    }
+	
+	@Test public void testGetRootDirAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+			}
+		};
+		
+		try {
+			drive.getRootDir(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetRootDirAsync failed");
 		}
     }
 
 	@Test public void testCreateDirectory() {
 		Directory directory = null;
 		try {
-			String pathName = "/newOneDriveDir" + System.currentTimeMillis();
+			String pathName = "/testCreateDirectory" + System.currentTimeMillis();
 			directory = drive.createDirectory(pathName).get();
 			assertNotNull(directory);
 
@@ -58,11 +113,51 @@ public class OneDriveDriveTest {
 			assertNotNull(secondLevelDir);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("createDirectory failed");
+			fail("testCreateDirectory failed");
 		}
 		finally {
 			try {
 				directory.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				fail();
+			}
+		}
+    }
+	
+	private Directory testDirectory = null;
+	@Test public void testCreateDirectoryAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+				testDirectory = directory;
+			}
+		};
+
+		try {
+			String pathName = "/testCreateDirectoryAsync" + System.currentTimeMillis();
+			drive.createDirectory(pathName, callback).get();
+			assertTrue(callbackInvoked);
+
+			pathName += "/" + System.currentTimeMillis();
+			Directory secondLevelDir = drive.createDirectory(pathName).get();
+			assertNotNull(secondLevelDir);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCreateDirectoryAsync failed");
+		}
+		finally {
+			try {
+				testDirectory.deleteItem().get();
 			} catch (Exception ex) {
 				ex.printStackTrace();
 				fail();
@@ -91,11 +186,47 @@ public class OneDriveDriveTest {
 			directory = drive.getDirectory(pathName).get();
 			assertNotNull(directory);
 		} catch (InterruptedException | ExecutionException e) {
-			fail("getDirectory failed");
+			fail("testGetDirectory failed");
 		}		
 		finally {
 			try {
 				directory.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				fail();
+			}
+		}
+    }
+	
+	@Test public void testGetDirectoryAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+				testDirectory = directory;
+			}
+		};
+
+		try {
+			String pathName = "/testGetDirectoryAsync" + System.currentTimeMillis();
+			assertNotNull(drive.createDirectory(pathName).get());
+
+			drive.getDirectory(pathName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			fail("testGetDirectoryAsync failed");
+		}		
+		finally {
+			try {
+				testDirectory.deleteItem().get();
 			} catch (Exception ex) {
 				ex.printStackTrace();
 				fail();
@@ -122,11 +253,47 @@ public class OneDriveDriveTest {
 			assertNotNull(file);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("createFile failed");
+			fail("testCreateFile failed");
 		}
 		finally {
 			try {
 				file.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				fail();
+			}
+		}
+    }
+	
+	private File testFile = null;
+	@Test public void testCreateFileAsync() {
+		callbackInvoked = false;
+		Callback<File> callback = new Callback<File>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(File file) {
+				callbackInvoked = true;
+				assertNotNull(file);
+				testFile = file;
+			}
+		};
+
+		try {
+			String pathName = "/testCreateFileAsync";
+			drive.createFile(pathName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCreateFileAsync failed");
+		}
+		finally {
+			try {
+				testFile.deleteItem().get();
 			} catch (Exception ex) {
 				ex.printStackTrace();
 				fail();
@@ -148,18 +315,54 @@ public class OneDriveDriveTest {
 	@Test public void testGetFile() {
 		File file = null;
 		try {
-			String pathName = "/newOneDriveFile" + System.currentTimeMillis();
+			String pathName = "/testGetFile" + System.currentTimeMillis();
 			file = drive.createFile(pathName).get();
 			assertNotNull(file);
 			file = drive.getFile(pathName).get();
 			assertNotNull(file);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("getFile failed");
+			fail("testGetFile failed");
 		}
 		finally {
 			try {
 				file.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				fail();
+			}
+		}
+    }
+	
+	@Test public void testGetFileAsync() {
+		callbackInvoked = false;
+		Callback<File> callback = new Callback<File>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(File file) {
+				callbackInvoked = true;
+				assertNotNull(file);
+				testFile = file;
+			}
+		};
+
+		try {
+			String pathName = "/testGetFileAsync" + System.currentTimeMillis();
+			assertNotNull(drive.createFile(pathName).get());
+			drive.getFile(pathName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetFileAsync failed");
+		}
+		finally {
+			try {
+				testFile.deleteItem().get();
 			} catch (Exception ex) {
 				ex.printStackTrace();
 				fail();
@@ -218,6 +421,59 @@ public class OneDriveDriveTest {
 				directory.deleteItem().get();
 			} catch (Exception ex) {
 				ex.printStackTrace();
+				fail();
+			}
+		}
+    }
+	
+	@Test public void testGetItemInfoAsync() {
+		callbackInvoked = false;
+		Callback<ItemInfo> callback = new Callback<ItemInfo>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(ItemInfo info) {
+				callbackInvoked = true;
+				assertNotNull(info);
+				assertTrue(info.containsKey(ItemInfo.name));
+				assertTrue(info.containsKey(ItemInfo.type));
+				assertTrue(info.containsKey(ItemInfo.itemId));
+			}
+		};
+
+		try {
+			//1. file
+			String name = "testGetItemInfoAsync_File.txt";
+			String pathName = "/" + name;
+			testFile = drive.createFile(pathName).get();
+			assertNotNull(testFile);
+
+			drive.getItemInfo(pathName, callback).get();
+			assertTrue(callbackInvoked);
+			
+			//2. directory
+			name = "testGetItemInfoAsync_Dir";
+			pathName = "/" + name;
+			testDirectory = drive.createDirectory(pathName).get();
+			assertNotNull(testDirectory);
+
+			callbackInvoked = false;
+			drive.getItemInfo(pathName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetItemInfoAsync failed");
+		}
+		finally {
+			try {
+				testFile.deleteItem().get();
+				testDirectory.deleteItem().get();
+			} catch (Exception e) {
+				e.printStackTrace();
 				fail();
 			}
 		}

--- a/src/test/java/org/elastos/hive/OneDrive/OneDriveFileOperatorTest.java
+++ b/src/test/java/org/elastos/hive/OneDrive/OneDriveFileOperatorTest.java
@@ -52,10 +52,6 @@ public class OneDriveFileOperatorTest {
 					tmpBuf.flip();
 					tmpBuf.get(bytes, 0, len);
 					readBuf.put(bytes);
-					
-					//write the content to a file.
-//					String localTestReadFile = String.format("%s/%s", System.getProperty("user.dir"), "tmp.txt");
-//					ByteBuffer2File(localTestReadFile, tmpBuf);
 				}
 			}
 

--- a/src/test/java/org/elastos/hive/ipfs/IpfsClientTest.java
+++ b/src/test/java/org/elastos/hive/ipfs/IpfsClientTest.java
@@ -1,19 +1,23 @@
 package org.elastos.hive.ipfs;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.ExecutionException;
 
+import org.elastos.hive.Callback;
 import org.elastos.hive.Client;
 import org.elastos.hive.Drive;
 import org.elastos.hive.DriveType;
+import org.elastos.hive.HiveException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class IpfsClientTest {
 	private static Client client;
+	private boolean callbackInvoked = false;
 
 	@Test public void testGetInstance() {
 		assertNotNull(Client.getInstance(DriveType.hiveIpfs));
@@ -29,6 +33,34 @@ public class IpfsClientTest {
 			fail("getInfo failed");
 		}
 	}
+	
+	@Test
+	public void testGetInfoAsync(){
+		callbackInvoked = false;
+		Callback<Client.Info> callback = new Callback<Client.Info>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Client.Info body) {
+				callbackInvoked = true;
+				Client.Info info = body ;
+				assertNotNull(info);
+				assertNotNull(info.get(Client.Info.userId));
+			}
+		};
+
+		try {
+			client.getInfo(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetInfoAsync failed");
+		}
+	}
 
 	@Test public void testGetDefaultDrive() {
 		try {
@@ -37,6 +69,32 @@ public class IpfsClientTest {
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testGetDefaultDrive failed");
+		}
+	}
+	
+	@Test
+	public void testGetDefaultDriveAsync(){
+		callbackInvoked = false;
+		Callback<Drive> callback = new Callback<Drive>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Drive drive) {
+				callbackInvoked = true;
+				assertNotNull(drive);
+			}
+		};
+
+		try {
+			client.getDefaultDrive(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetDefaultDriveAsync failed");
 		}
 	}
 

--- a/src/test/java/org/elastos/hive/ipfs/IpfsDirectoryTest.java
+++ b/src/test/java/org/elastos/hive/ipfs/IpfsDirectoryTest.java
@@ -15,7 +15,9 @@ public class IpfsDirectoryTest {
 	private static Drive drive;
 	private static Client client;
 	private static Directory testDirectory;
+	private static Directory testDirectoryAsync;
 	private static Directory parentDirForMoveTo;
+	private boolean callbackInvoked = false;
 
 	@Test public void testRootDirectory() {
 		try {
@@ -24,6 +26,31 @@ public class IpfsDirectoryTest {
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testRootDirectory failed");
+		}
+	}
+	
+	@Test public void testRootDirectoryAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+			}
+		};
+		
+		try {
+			drive.getRootDir(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testRootDirectoryAsync failed");
 		}
 	}
 
@@ -60,6 +87,34 @@ public class IpfsDirectoryTest {
 		}
 	}
 
+	@Test public void testGetInfoAsync() {
+		callbackInvoked = false;
+		Callback<Directory.Info> callback = new Callback<Directory.Info>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory.Info info) {
+				callbackInvoked = true;
+				assertNotNull(info);
+				assertNotNull(info.get(Directory.Info.itemId));
+				assertNotNull(info.get(Directory.Info.name));
+				assertTrue(info.containsKey(Directory.Info.childCount));
+			}
+		};
+		
+		try {
+			testDirectory.getInfo(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetInfoAsync failed");
+		}
+	}
+	
 	@Test public void testCreateDirectory() {
 		try {
 			String childName = "testCreateDirectory" + System.currentTimeMillis();
@@ -68,6 +123,32 @@ public class IpfsDirectoryTest {
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testCreateDirectory failed");
+		}
+	}
+	
+	@Test public void testCreateDirectoryAsync() {
+		callbackInvoked = false;
+		Callback<Directory> callback = new Callback<Directory>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Directory directory) {
+				callbackInvoked = true;
+				assertNotNull(directory);
+			}
+		};
+
+		try {
+			String childName = "testCreateDirectoryAsync" + System.currentTimeMillis();
+			testDirectory.createDirectory(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCreateDirectoryAsync failed");
 		}
 	}
 
@@ -95,6 +176,36 @@ public class IpfsDirectoryTest {
 			fail("testGetDirectory failed");
 		}
 	}
+	
+	@Test public void testGetDirectoryAsync() {
+		try {
+			String childName = "testGetDirectoryAsync" + System.currentTimeMillis();
+			Directory child = testDirectory.createDirectory(childName).get();
+			assertNotNull(child);
+
+			callbackInvoked = false;
+			Callback<Directory> callback = new Callback<Directory>() {
+				@Override
+				public void onError(HiveException e) {
+					e.printStackTrace();
+					fail();
+				}
+
+				@Override
+				public void onSuccess(Directory childDir) {
+					callbackInvoked = true;
+					assertNotNull(childDir);
+					assertEquals(child.getPath(), childDir.getPath());
+				}
+			};
+
+			testDirectory.getDirectory(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetDirectoryAsync failed");
+		}
+	}
 
 	@Test public void testCreateFile() {
 		try {
@@ -104,6 +215,32 @@ public class IpfsDirectoryTest {
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testCreateFile failed");
+		}
+	}
+	
+	@Test public void testCreateFileAsync() {
+		callbackInvoked = false;
+		Callback<File> callback = new Callback<File>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(File file) {
+				callbackInvoked = true;
+				assertNotNull(file);
+			}
+		};
+
+		try {
+			String childName = "testCreateFileAsync" + System.currentTimeMillis();
+			testDirectory.createFile(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCreateFileAsync failed");
 		}
 	}
 
@@ -130,6 +267,36 @@ public class IpfsDirectoryTest {
 			fail("testGetFile failed");
 		}
 	}
+	
+	@Test public void testGetFileAsync() {
+		try {
+			String childName = "testGetFileAsync" + System.currentTimeMillis();
+			File child = testDirectory.createFile(childName).get();
+			assertNotNull(child);
+			
+			callbackInvoked = false;
+			Callback<File> callback = new Callback<File>() {
+				@Override
+				public void onError(HiveException e) {
+					e.printStackTrace();
+					fail();
+				}
+
+				@Override
+				public void onSuccess(File file) {
+					callbackInvoked = true;
+					assertNotNull(file);
+					assertEquals(child.getPath(), file.getPath());
+				}
+			};
+			
+			testDirectory.getFile(childName, callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetFileAsync failed");
+		}
+	}
 
 	@Test public void testGetChildren() {
 		try {
@@ -138,6 +305,31 @@ public class IpfsDirectoryTest {
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testGetChildren failed");
+		}
+	}
+	
+	@Test public void testGetChildrenAsync() {
+		callbackInvoked = false;
+		Callback<Children> callback = new Callback<Children>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Children child) {
+				callbackInvoked = true;
+				assertNotNull(child);
+			}
+		};
+		
+		try {
+			testDirectory.getChildren(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetChildrenAsync failed");
 		}
 	}
 
@@ -231,7 +423,52 @@ public class IpfsDirectoryTest {
 	@Test public void testMoveTo() {
 		try {
 			String originPath = testDirectory.getPath();
+			int childCount = parentDirForMoveTo.getChildren().get().getContent().size();
 			testDirectory.moveTo(parentDirForMoveTo.getPath()).get();
+
+			//1. Check the parent has a new child.
+			int newChildCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
+
+			//2. Check: the origin and the new path is different
+			assertFalse(originPath.equals(testDirectory.getPath()));
+
+			//3. Check: the origin path is invalid.
+			try {
+				drive.getDirectory(originPath).get();
+				fail(String.format("The a directory has moved, the origin path is invalid: %s", originPath));
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testMoveTo failed");
+		}
+	}
+	
+	@Test public void testMoveToAsync() {
+		callbackInvoked = false;
+		Callback<Void> callback = new Callback<Void>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Void none) {
+				callbackInvoked = true;
+			}
+		};
+
+		try {
+			int childCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			String originPath = testDirectoryAsync.getPath();
+			testDirectoryAsync.moveTo(parentDirForMoveTo.getPath(), callback).get();
+			assertTrue(callbackInvoked);
+
+			int newChildCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 
 			//1. Check the parent has a new child.
 			Children children = parentDirForMoveTo.getChildren().get();
@@ -250,24 +487,68 @@ public class IpfsDirectoryTest {
 			}
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("testMoveToInvalid failed");
+			fail("testMoveToAsync failed");
 		}
 	}
 
 	@Test public void testCopyTo() {
 		Directory parentDir = null;
 		try {
-			String parentPath = "/parentDir" + System.currentTimeMillis();
+			String parentPath = "/copyToParentDir" + System.currentTimeMillis();
 			parentDir = drive.createDirectory(parentPath).get();
 			assertNotNull(parentDir);
+			
+			int childCount = parentDir.getChildren().get().getContent().size();
 			testDirectory.copyTo(parentPath).get();
 
-			Children children = parentDir.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			Thread.sleep(5000);
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testCopyTo failed");
+		}
+		finally {
+			try {
+				parentDir.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				fail();
+			}
+		}
+	}
+	
+	@Test public void testCopyToAsync() {
+		callbackInvoked = false;
+		Callback<Void> callback = new Callback<Void>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Void none) {
+				callbackInvoked = true;
+			}
+		};
+
+		Directory parentDir = null;
+		try {
+			String parentPath = "/copyToAsyncParentDir" + System.currentTimeMillis();
+			parentDir = drive.createDirectory(parentPath).get();
+			assertNotNull(parentDir);
+			
+			int childCount = parentDir.getChildren().get().getContent().size();
+			testDirectory.copyTo(parentPath, callback).get();
+			assertTrue(callbackInvoked);
+
+			Thread.sleep(5000);
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCopyToAsync failed");
 		}
 		finally {
 			try {
@@ -286,12 +567,13 @@ public class IpfsDirectoryTest {
 			parentDir = drive.createDirectory(parentPath).get();
 			assertNotNull(parentDir);
 			String originPath = testDirectory.getPath();
-			Void placeHolder = testDirectory.copyTo(parentPath).get();
+			int childCount = parentDir.getChildren().get().getContent().size();
+			testDirectory.copyTo(parentPath).get();
 
 			//1. Check the parent has a new child.
-			Children children = parentDir.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			Thread.sleep(2000);
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 
 			//2. Check: the origin and the new path is same
 			assertEquals(originPath, testDirectory.getPath());
@@ -327,6 +609,10 @@ public class IpfsDirectoryTest {
 			testDirectory = drive.createDirectory("/testDirectory" + System.currentTimeMillis()).get();
 			assertNotNull(testDirectory);
 			assertNotNull(testDirectory.getPath());
+			
+			testDirectoryAsync = drive.createDirectory("/testDirectoryAsync" + System.currentTimeMillis()).get();
+			assertNotNull(testDirectoryAsync);
+			assertNotNull(testDirectoryAsync.getPath());
 			parentDirForMoveTo = drive.createDirectory("/parentDirForMoveTo" + System.currentTimeMillis()).get();
 			assertNotNull(parentDirForMoveTo);
 		} catch (Exception e) {
@@ -339,6 +625,7 @@ public class IpfsDirectoryTest {
     static public void tearDown() throws Exception {
     	try {
     		testDirectory.deleteItem().get();
+    		testDirectoryAsync.deleteItem().get();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/test/java/org/elastos/hive/ipfs/IpfsFileOperatorTest.java
+++ b/src/test/java/org/elastos/hive/ipfs/IpfsFileOperatorTest.java
@@ -51,10 +51,6 @@ public class IpfsFileOperatorTest {
 					tmpBuf.flip();
 					tmpBuf.get(bytes, 0, len);
 					readBuf.put(bytes);
-					
-					//write the content to a file.
-//					String localTestReadFile = String.format("%s/%s", System.getProperty("user.dir"), "tmp.txt");
-//					ByteBuffer2File(localTestReadFile, tmpBuf);
 				}
 			}
 

--- a/src/test/java/org/elastos/hive/ipfs/IpfsFileTest.java
+++ b/src/test/java/org/elastos/hive/ipfs/IpfsFileTest.java
@@ -2,11 +2,13 @@ package org.elastos.hive.ipfs;
 
 import java.util.concurrent.ExecutionException;
 
-import org.elastos.hive.Children;
+import org.elastos.hive.Callback;
 import org.elastos.hive.Client;
 import org.elastos.hive.Directory;
 import org.elastos.hive.Drive;
 import org.elastos.hive.File;
+import org.elastos.hive.HiveException;
+import org.elastos.hive.Void;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -18,6 +20,7 @@ public class IpfsFileTest {
 	private static Client client;
 	private static File testFile;
 	private static Directory parentDirForMoveTo;
+	private boolean callbackInvoked = false;
 
 	@Test public void testGetId() {
 		assertNotNull(testFile.getId());
@@ -48,19 +51,91 @@ public class IpfsFileTest {
 			assertTrue(info.containsKey(File.Info.size));
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("getInfo failed");
+			fail("testGetInfo failed");
 		}
 	}
 
+	@Test public void testGetInfoAsync() {
+		callbackInvoked = false;
+		Callback<File.Info> callback = new Callback<File.Info>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(File.Info info) {
+				callbackInvoked = true;
+				assertNotNull(info);
+				assertNotNull(info.get(File.Info.name));
+				assertNotNull(info.get(File.Info.itemId));
+				assertTrue(info.containsKey(File.Info.size));
+			}
+		};
+		
+		try {
+			testFile.getInfo(callback).get();
+			assertTrue(callbackInvoked);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testGetInfoAsync failed");
+		}
+	}
+	
 	@Test public void testMoveTo() {
 		try {
-			String originPath = testFile.getPath();
-			testFile.moveTo(parentDirForMoveTo.getPath()).get();
+			File testMoveToFile = drive.createFile("/testMoveToFile" + System.currentTimeMillis()).get();
+			assertNotNull(testMoveToFile);
+			
+			String originPath = testMoveToFile.getPath();
+			int childCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			testMoveToFile.moveTo(parentDirForMoveTo.getPath()).get();
 
 			//1. Check the parent has a new child.
-			Children children = parentDirForMoveTo.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			int newChildCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
+
+			//2. Check: the origin and the new path is different
+			assertFalse(originPath.equals(testMoveToFile.getPath()));
+
+			//3. Check: the origin path is invalid.
+			try {
+				drive.getDirectory(originPath).get();
+				fail(String.format("The file has moved, the origin path is invalid: %s", originPath));
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testMoveTo failed");
+		}
+	}
+	
+	@Test public void testMoveToAsync() {
+		callbackInvoked = false;
+		Callback<Void> callback = new Callback<Void>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Void none) {
+				callbackInvoked = true;
+			}
+		};
+		
+		try {
+			String originPath = testFile.getPath();
+			int childCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			testFile.moveTo(parentDirForMoveTo.getPath(), callback).get();
+			assertTrue(callbackInvoked);
+
+			//1. Check the parent has a new child.
+			int newChildCount = parentDirForMoveTo.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 
 			//2. Check: the origin and the new path is different
 			assertFalse(originPath.equals(testFile.getPath()));
@@ -74,25 +149,63 @@ public class IpfsFileTest {
 			}
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
-			fail("testMoveToInvalid failed");
+			fail("testMoveToAsync failed");
 		}
 	}
 
 	@Test public void testCopyTo() {
 		Directory parentDir = null;
 		try {
-			String parentPath = "/parentDir" + System.currentTimeMillis();
+			String parentPath = "/testCopyToParentDir" + System.currentTimeMillis();
 			parentDir = drive.createDirectory(parentPath).get();
 			assertNotNull(parentDir);
+			int childCount = parentDir.getChildren().get().getContent().size();
 			testFile.copyTo(parentPath).get();
 
-			Thread.sleep(5000);
-			Children children = parentDir.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 		} catch (InterruptedException | ExecutionException e) {
 			e.printStackTrace();
 			fail("testCopyTo failed");
+		}
+		finally {
+			try {
+				parentDir.deleteItem().get();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+			}
+		}
+	}
+	
+	@Test public void testCopyToAsync() {
+		callbackInvoked = false;
+		Callback<Void> callback = new Callback<Void>() {
+			@Override
+			public void onError(HiveException e) {
+				e.printStackTrace();
+				fail();
+			}
+
+			@Override
+			public void onSuccess(Void none) {
+				callbackInvoked = true;
+			}
+		};
+
+		Directory parentDir = null;
+		try {
+			String parentPath = "/testCopyToAsyncParentDir" + System.currentTimeMillis();
+			parentDir = drive.createDirectory(parentPath).get();
+			assertNotNull(parentDir);
+			int childCount = parentDir.getChildren().get().getContent().size();
+			testFile.copyTo(parentPath, callback).get();
+			assertTrue(callbackInvoked);
+
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+			fail("testCopyToAsync failed");
 		}
 		finally {
 			try {
@@ -110,13 +223,12 @@ public class IpfsFileTest {
 			parentDir = drive.createDirectory(parentPath).get();
 			assertNotNull(parentDir);
 			String originPath = testFile.getPath();
+			int childCount = parentDir.getChildren().get().getContent().size();
 			testFile.copyTo(parentPath).get();
 
 			//1. Check the parent has a new child.
-			Thread.sleep(2000);
-			Children children = parentDir.getChildren().get();
-			assertNotNull(children);
-			assertEquals(1, children.getContent().size());
+			int newChildCount = parentDir.getChildren().get().getContent().size();
+			assertEquals(childCount + 1, newChildCount);
 
 			//2. Check: the origin and the new path is same
 			assertEquals(originPath, testFile.getPath());


### PR DESCRIPTION
1. Fixed the bug about OneDrive interfaces: Directory.getInfo; 
2. Add the testcases about Using interfaces with callback.